### PR TITLE
Fix support for multiple of same class type

### DIFF
--- a/scraper/scraper/Scraper.ts
+++ b/scraper/scraper/Scraper.ts
@@ -30,7 +30,10 @@ export class Scraper {
     this.logger = getLogger('Scraper');
   }
 
-  async scrapePages<T>(urls: string[], handler: (page: cheerio.CheerioAPI, url: string) => Promise<T>) {
+  async scrapePages<T>(
+    urls: string[],
+    handler: (page: cheerio.CheerioAPI, url: string) => Promise<T>,
+  ): Promise<T[]> {
     const queue = new AsyncQueue<string, T>(this.maxRequests);
     queue.enqueue(urls);
     const processor = async (url: string) => {

--- a/scraper/scraper/unsw/TimetableScraper.spec.ts
+++ b/scraper/scraper/unsw/TimetableScraper.spec.ts
@@ -133,6 +133,8 @@ describe('parsing utilities', () => {
     ${'Lecture Sequence 1 of 2'}  | ${'LE1'}
     ${'Lecture Sequence 2 of 2'}  | ${'LE2'}
     ${'Tutorial Sequence 1 of 2'} | ${'TU1'}
+    ${'Tutorial 1 of 2'}          | ${'TU1'}
+    ${'Laboratory 1 of 2'}        | ${'LA1'}
   `('getShortActivity("$long") = "$short"', ({ long, short }) => {
     expect(getShortActivity(long)).toEqual(short);
   });

--- a/scraper/scraper/unsw/TimetableScraper.ts
+++ b/scraper/scraper/unsw/TimetableScraper.ts
@@ -388,7 +388,11 @@ export function getShortActivity(activity: string) {
   const mapping: { [long: string]: string } = {
     'tutorial-laboratory': 'TLB',
   };
-  const short = mapping[activity.toLowerCase()] || activity.slice(0, 3).toUpperCase();
+  let short: string = mapping[activity.toLowerCase()] || activity.slice(0, 3).toUpperCase();
+  const sequenceNumber: string | undefined = activity.match(/([0-9]+) of ([0-9]+)/)?.[1];
+  if (sequenceNumber) {
+    short = short.slice(0, 2) + sequenceNumber;
+  }
   return short;
 }
 

--- a/scraper/scraper/unsw/TimetableScraper.ts
+++ b/scraper/scraper/unsw/TimetableScraper.ts
@@ -388,8 +388,8 @@ export function getShortActivity(activity: string) {
   const mapping: { [long: string]: string } = {
     'tutorial-laboratory': 'TLB',
   };
-  let short: string = mapping[activity.toLowerCase()] || activity.slice(0, 3).toUpperCase();
-  const sequenceNumber: string | undefined = activity.match(/([0-9]+) of ([0-9]+)/)?.[1];
+  let short = mapping[activity.toLowerCase()] || activity.slice(0, 3).toUpperCase();
+  const sequenceNumber = activity.match(/([0-9]+) of ([0-9]+)/)?.[1];
   if (sequenceNumber) {
     short = short.slice(0, 2) + sequenceNumber;
   }


### PR DESCRIPTION
The expected codes in this case seem to be (e.g) LE1 and LE2 for each option. This interprets the usual "1 of 2" format given in the strings.