### PR TITLE
Concurrent event time

### DIFF
--- a/scraper/scraper/unsw/TimetableScraper.ts
+++ b/scraper/scraper/unsw/TimetableScraper.ts
@@ -388,7 +388,11 @@ export function getShortActivity(activity: string) {
   const mapping: { [long: string]: string } = {
     'tutorial-laboratory': 'TLB',
   };
-  const short = mapping[activity.toLowerCase()] || activity.slice(0, 3).toUpperCase();
+  let short: string = mapping[activity.toLowerCase()] || activity.slice(0, 3).toUpperCase();
+  const sequenceNumber: string | undefined = activity.match(/([0-9]+) of ([0-9]+)/)?.[1];
+  if (sequenceNumber) {
+    short = short.slice(0, 2) + sequenceNumber;
+  }
   return short;
 }
 

--- a/scraper/scraper/unsw/TimetableScraper.ts
+++ b/scraper/scraper/unsw/TimetableScraper.ts
@@ -1,5 +1,7 @@
 import * as cheerio from 'cheerio';
 import type { Element } from 'domhandler';
+import { time } from 'console';
+import { find } from 'cheerio/dist/commonjs/api/traversing';
 import { Scraper } from '../Scraper';
 import type { CourseData } from '../../../app/src/state/Course';
 import { ClassTime, DeliveryType, StreamData } from '../../../app/src/state/Stream';
@@ -9,8 +11,6 @@ import { removeDuplicateStreams } from '../commonUtils';
 import { getLogger } from '../../logging';
 import { UNSW } from './scrapeUNSW';
 import axios from '../axios';
-import { time } from 'console';
-import { find } from 'cheerio/dist/commonjs/api/traversing';
 
 const logger = getLogger('TimetableScraper', { campus: UNSW });
 
@@ -214,15 +214,15 @@ export class TimetableScraper {
           const timeObject: ClassTime = {
             time: timeStr,
             location: locationName || undefined,
-            weeks: weeks,
+            weeks,
           };
 
           // check if 'time' already exists in "times"
-          let toAppend = findWeekToMerge(stream, timeObject)
+          const toAppend = findWeekToMerge(stream, timeObject);
           // let toAppend = stream.times.find(obj => obj.time === timeObject.time);
           if (toAppend) {
-            toAppend.weeks = toAppend.weeks?.concat(',' + weeks);
-            continue; 
+            toAppend.weeks = toAppend.weeks?.concat(`,${weeks}`);
+            continue;
           }
 
           if (!shouldSkipTime(timeObject)) {
@@ -446,7 +446,7 @@ export function isCourseEnrolment(data: StreamTableData) {
 
 export function shouldMergeWeeks(curTime: string, times: ClassTime[], code: string) {
   return times.some(obj => obj.time === curTime);
-} 
+}
 
 export function findWeekToMerge(stream: StreamData, timeObject: ClassTime) {
   return stream.times.find(obj => obj.time === timeObject.time);

--- a/scraper/scraper/unsw/TimetableScraper.ts
+++ b/scraper/scraper/unsw/TimetableScraper.ts
@@ -9,6 +9,8 @@ import { removeDuplicateStreams } from '../commonUtils';
 import { getLogger } from '../../logging';
 import { UNSW } from './scrapeUNSW';
 import axios from '../axios';
+import { time } from 'console';
+import { find } from 'cheerio/dist/commonjs/api/traversing';
 
 const logger = getLogger('TimetableScraper', { campus: UNSW });
 
@@ -212,8 +214,16 @@ export class TimetableScraper {
           const timeObject: ClassTime = {
             time: timeStr,
             location: locationName || undefined,
-            weeks,
+            weeks: weeks,
           };
+
+          // check if 'time' already exists in "times"
+          let toAppend = findWeekToMerge(stream, timeObject)
+          // let toAppend = stream.times.find(obj => obj.time === timeObject.time);
+          if (toAppend) {
+            toAppend.weeks = toAppend.weeks?.concat(',' + weeks);
+            continue; 
+          }
 
           if (!shouldSkipTime(timeObject)) {
             stream.times.push(timeObject);
@@ -432,4 +442,12 @@ export function isOnWeekend(time: string) {
 
 export function isCourseEnrolment(data: StreamTableData) {
   return data.Activity.toLowerCase() === 'course enrolment';
+}
+
+export function shouldMergeWeeks(curTime: string, times: ClassTime[], code: string) {
+  return times.some(obj => obj.time === curTime);
+} 
+
+export function findWeekToMerge(stream: StreamData, timeObject: ClassTime) {
+  return stream.times.find(obj => obj.time === timeObject.time);
 }


### PR DESCRIPTION
when adding "streams" to a course, will check all pre-existing "streams" to see if that time already exists. If so, that stream's times will be appended to the existing stream. This stops extra objects being generated in the app. 