### PR TITLE
Fix local scraper workflow

### DIFF
--- a/scraper/getAEST.spec.ts
+++ b/scraper/getAEST.spec.ts
@@ -4,5 +4,5 @@ it('returns expected time', () => {
   // Test must be run in AEST timezone
   const expected = new Date().getTime();
   const result = getAEST().toDate().getTime();
-  expect(result - expected).toBeLessThanOrEqual(5);
+  expect(result - expected).toBeLessThanOrEqual(100);
 });

--- a/scraper/scraper/unsw/launchTimetable.ts
+++ b/scraper/scraper/unsw/launchTimetable.ts
@@ -1,9 +1,18 @@
 // Use "npx tsx launchTimetable.ts" to run the scraper locally
 
-import { writeFileSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { TimetableScraper } from './TimetableScraper';
+import { splitByTerm } from './scrapeUNSW';
 
-const runScraper = async (useFilters = false) => {
+const runScraper = async ({
+  useFilters = false,
+  saveToFile = true,
+  prettyPrint = true,
+}: {
+  useFilters?: boolean,
+  saveToFile?: boolean,
+  prettyPrint?: boolean,
+} = {}) => {
   const timetable = new TimetableScraper();
   timetable.state = undefined;
   if (useFilters) {
@@ -11,7 +20,27 @@ const runScraper = async (useFilters = false) => {
   }
   await timetable.setup();
   const result = await timetable.scrape();
-  writeFileSync('test_timetable.json', JSON.stringify(result, undefined, 2));
+
+  if (saveToFile) {
+    const basePath = '../../../app/public'
+    let path = `${basePath}/unsw/data.json`;
+    if (!existsSync(basePath)) {
+      console.warn('Could not find app/public/ directory, writing to working directory');
+      path = 'data.json';
+    } else {
+      const dir = path.slice(0, path.lastIndexOf('/'))
+      if (!existsSync(dir)) {
+        mkdirSync(dir);
+      }
+    }
+
+    const resultsByTerm = splitByTerm(result);
+    let current = resultsByTerm.find(t => t.current);
+    writeFileSync(
+      path,
+      JSON.stringify(current, undefined, prettyPrint ? 2 : undefined),
+    );
+  }
 };
 
 runScraper();

--- a/scraper/scraper/unsw/launchTimetable.ts
+++ b/scraper/scraper/unsw/launchTimetable.ts
@@ -22,20 +22,20 @@ const runScraper = async ({
   const result = await timetable.scrape();
 
   if (saveToFile) {
-    const basePath = '../../../app/public'
+    const basePath = '../../../app/public';
     let path = `${basePath}/unsw/data.json`;
     if (!existsSync(basePath)) {
       console.warn('Could not find app/public/ directory, writing to working directory');
       path = 'data.json';
     } else {
-      const dir = path.slice(0, path.lastIndexOf('/'))
+      const dir = path.slice(0, path.lastIndexOf('/'));
       if (!existsSync(dir)) {
         mkdirSync(dir);
       }
     }
 
     const resultsByTerm = splitByTerm(result);
-    let current = resultsByTerm.find(t => t.current);
+    const current = resultsByTerm.find(t => t.current);
     writeFileSync(
       path,
       JSON.stringify(current, undefined, prettyPrint ? 2 : undefined),


### PR DESCRIPTION
This commit aims to create a simple workflow for running the scraper locally and running CrossAngles with the resultant data for manual verification in development.

Also in this commit:
* Remove old reference to "merging" timetable data
* Separate splitByTerm code into own function
* Fix minor logging glitch while selecting current term